### PR TITLE
Confine to server 2012/win8

### DIFF
--- a/lib/puppet/provider/windowsfirewall/powershell.rb
+++ b/lib/puppet/provider/windowsfirewall/powershell.rb
@@ -1,5 +1,9 @@
 Puppet::Type.type(:windowsfirewall).provide(:powershell) do
   confine :operatingsystem => :windows
+  confine :kernelmajorversion do |kernelversion|
+    kernelversion >= 6.2
+  end
+
   commands :powershell =>
     if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe")
       "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"


### PR DESCRIPTION
The NetFirewallProfile command wasn't introduced until server 2012
and windows 8, so I added an additional confine to limit it to
any version of windows matching kernel 6.2 or greater.

The rest of the settings seem to work well and I really like the new puppet face!